### PR TITLE
Remove `readODS::read.ods()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Aims to facilitate the reduction of elemental microchemistry data f
 Repository: CRAN
 Depends: R (>= 3.2.3)
 Imports: gdata, shiny,devtools, shinyjs, gnumeric, R6, shinydashboard,
-        abind, stringr, lmtest, tcltk,tcltk2, reader, readODS, readxl,
+        abind, stringr, lmtest, tcltk,tcltk2, reader, readODS (>= 1.7.0), readxl,
         EnvStats, outliers, zoo, colourpicker, stats, graphics, utils,
         httpuv
 License: GPL (>=2)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,7 +13,7 @@ importFrom(tcltk2, tk2text)
 importFrom(gdata, read.xls)
 importFrom(lmtest, dwtest, hmctest)
 importFrom(colourpicker, colourInput)
-importFrom("readODS", read.ods)
+importFrom("readODS", "read_ods")
 importFrom("grDevices", "bmp", "colorRampPalette", "dev.off", "jpeg",
              "png", "rainbow", "tiff")
 importFrom("graphics", "abline", "layout", "legend", "mtext", "par",

--- a/R/App.R
+++ b/R/App.R
@@ -78,45 +78,8 @@ runElementR <- function(){ # nocov start
 			df <- read.table(x, header = TRUE, sep = sep, dec = dec)
 		} 
 		if(str_detect(x, ".ods")){
-
-			df <- read.ods(x)[[1]]
-
-			colnames(df) <- df[1,]
-			df <- df[-1,]
-
-			col <- seq(from = 1, to = ncol(df), by = 1)
-
-			err <- 0
-
-			for(i in col){
-
-				for(j in seq(from = 1, to = nrow(df), by = 1)){
-
-					if(is.na(df[j,i]) | is.null(df[j,i])) {
-
-					} else {
-
-						if(suppressWarnings(is.na(as.numeric(as.character(df[j,i]))))) {
-
-							err <- 1
-
-						} else {
-
-						}
-
-					}
-
-				}
-
-			}
-
-			if(err == 0){
-				df <- as.matrix(as.data.frame(lapply(df, as.numeric)))
-			} else {
-
-			}
-
-		} 
+                  df <- read_ods(x)
+                }
 		return(df)
 	}
 	##################################################################################################

--- a/R/classElementR_R6.R
+++ b/R/classElementR_R6.R
@@ -18,44 +18,7 @@ readData <- function(x, sep = ";", dec = "."){
   } else {}
   
   if(str_detect(x, ".ods")){
-    
-    df <- read.ods(x)[[1]]
-    
-    colnames(df) <- df[1,]
-    df <- df[-1,]
-    
-    col <- seq(from = 1, to = ncol(df), by = 1)
-    
-    err <- 0
-    
-    for(i in col){
-      
-      for(j in seq(from = 1, to = nrow(df), by = 1)){
-        
-        if(is.na(df[j,i]) | is.null(df[j,i])) {
-          
-        } else {
-          
-          if(suppressWarnings(is.na(as.numeric(as.character(df[j,i]))))) {
-            
-            err <- 1
-            
-          } else {
-            
-          }
-          
-        }
-        
-      }
-      
-    }
-    
-    if(err == 0){
-      df <- as.matrix(as.data.frame(lapply(df, as.numeric)))
-    } else {
-      
-    }
-    
+    df <- read_ods(x)
   } else {}
   return(df)
 }


### PR DESCRIPTION
`read.ods()` will be removed in the upcoming CRAN version of readODS; this version uses `read_ods()` and the outcome is correct.